### PR TITLE
【Fixed】Issues/#1

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,11 @@ module FlowSample
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    # 「rails g」コマンドで余計なhelperやassetsを生成しないようにする。
+    config.generators do |g|
+      g.assets    false
+      g.helper    false
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,7 @@ module FlowSample
     config.active_record.raise_in_transactional_callbacks = true
 
     # 「rails g」コマンドで余計なhelperやassetsを生成しないようにする。
+    # もう一度pull requestするために、pushしてみる。
     config.generators do |g|
       g.assets    false
       g.helper    false


### PR DESCRIPTION
「rails g」コマンドで余計なhelperやassetsを生成しないようにする。